### PR TITLE
Add attempt to require bluebird first

### DIFF
--- a/promise.js
+++ b/promise.js
@@ -1,8 +1,6 @@
 
-module.exports = global.Promise
-
-if (!module.exports) {
-  try {
-    module.exports = require('bluebird')
-  } catch (_) {}
+try {
+  module.exports = require('bluebird')
+} catch (_) {
+  module.exports = global.Promise
 }


### PR DESCRIPTION
This is likely controversial, but in my opinion, if a developer has `bluebird` installed, we might as well take advantage of that fact, at least for now, considering that it is 40x faster than ES6 Promises. 

See https://github.com/petkaantonov/bluebird/tree/master/benchmark and https://github.com/angular/angular.js/issues/6697#issuecomment-42771111.

We can always switch back to the previous order when ES6 Promises are optimized in V8. I've tested the benchmarks on io.js and even with the V8 upgrade, native promises are still way slower than bluebird's implementation.